### PR TITLE
Add attacking as an action that can be performed.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.2+build.2
 loader_version=0.14.17
 
 # Mod Properties
-mod_version = 2.1.
+mod_version = 2.2
 maven_group = asd.fred
 archives_base_name = wynncraft-spell-caster
 

--- a/src/main/java/asd/fred/wynncraft_spell_caster/WynncraftSpellCasterClient.java
+++ b/src/main/java/asd/fred/wynncraft_spell_caster/WynncraftSpellCasterClient.java
@@ -21,9 +21,11 @@ public class WynncraftSpellCasterClient implements ClientModInitializer, ClientL
     private static final List<Boolean> spell2_clicks = Arrays.asList(true, true, true);
     private static final List<Boolean> spell3_clicks = Arrays.asList(true, false, false);
     private static final List<Boolean> spell4_clicks = Arrays.asList(true, true, false);
+    private static final List<Boolean> attack_clicks = Arrays.asList(false);
     public static KeyBinding attack_key;
     public static KeyBinding use_key;
     public static KeyBinding spell1_key, spell2_key, spell3_key, spell4_key;
+    public static KeyBinding attackQueue_key;
     public static KeyBinding config_key;
     public static Config.ConfigData config_data;
     public static ClickQueue clickQueue;
@@ -60,6 +62,7 @@ public class WynncraftSpellCasterClient implements ClientModInitializer, ClientL
         checkSpellKey(spell2_key, spell2_clicks);
         checkSpellKey(spell3_key, spell3_clicks);
         checkSpellKey(spell4_key, spell4_clicks);
+        checkSpellKey(attackQueue_key, attack_clicks);
     }
 
     private void registerKeybinds() {
@@ -69,6 +72,7 @@ public class WynncraftSpellCasterClient implements ClientModInitializer, ClientL
         spell2_key = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.wynncraft-spell-caster.spell.second", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "key.category.spell"));
         spell3_key = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.wynncraft-spell-caster.spell.third", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "key.category.spell"));
         spell4_key = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.wynncraft-spell-caster.spell.fourth", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "key.category.spell"));
+        attackQueue_key = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.wynncraft-spell-caster.spell.attack_queue", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "key.category.spell"));
     }
 
     private void checkSpellKey(KeyBinding spell_key, Collection<Boolean> spell_clicks) {

--- a/src/main/resources/assets/wynncraft-spell-caster/lang/en_us.json
+++ b/src/main/resources/assets/wynncraft-spell-caster/lang/en_us.json
@@ -4,6 +4,7 @@
   "key.wynncraft-spell-caster.spell.second": "Cast 2nd Spell",
   "key.wynncraft-spell-caster.spell.third": "Cast 3rd Spell",
   "key.wynncraft-spell-caster.spell.fourth": "Cast 4th Spell",
+  "key.wynncraft-spell-caster.spell.attack_queue": "Attack Once",
   "key.wynncraft-spell-caster.config": "Open Config",
 
   "screen.wynncraft-spell-caster.config.title" : "Wynncraft Spell Caster Config",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,7 +6,8 @@
   "name": "Wynncraft Spell Caster",
   "description": "A configurable spell macro mod for Wynncraft.",
   "authors": [
-    "Frederik"
+    "Frederik",
+    "KiliE"
   ],
   "contact": {
     "sources": "https://github.com/Freeder1k/Wynncraft-Spell-Caster"


### PR DESCRIPTION
Add attack as an action Spell Caster can perform to prevent issues with normal attacks interfering with the timing on Spell Caster on manasteal and other classes.
Legality of the change confirmed with a mod.